### PR TITLE
feat: implement signup success dialog and env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+
+/web
+/windows
+/linux
+/macos
+
+sign-up-successful.svg

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc901062556672b4138e18a4dc62a4be8f4b3c2"
+  revision: "3b62efc2a3da49882f43c372e0bc53daef7295a6"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
     - platform: android
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
     - platform: ios
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
     - platform: linux
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
     - platform: macos
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
     - platform: web
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
     - platform: windows
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
+      create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
+      base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
 
   # User provided section
 

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -11,4 +11,10 @@ class AppStrings {
   static const String help = "Help";
   static const String terms = "Terms & Conditions";
   static const String privacy = "Privacy Policy";
+
+  // Signup Success Dialog Strings
+  static const String signupSuccessTitle = "Signup successful";
+  static const String signupSuccessMessage =
+      "start receiving surprises from the people who matter.";
+  static const String signupSuccessButton = "Proceed to dashboard";
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zendvo/features/auth/presentation/pages/email_verification_screen.dart';
+import 'package:zendvo/features/auth/presentation/pages/signup_success_screen.dart';
 
 class AppRouter {
   static final GoRouter router = GoRouter(
@@ -13,6 +14,21 @@ class AppRouter {
           final email =
               state.uri.queryParameters['email'] ?? 'jo***3@gmail.com';
           return EmailVerificationScreen(email: email);
+        },
+      ),
+      GoRoute(
+        path: '/signup-success',
+        name: 'signup-success',
+        builder: (context, state) {
+          return SignupSuccessScreen(
+            onProceedToDashboard: () {
+              // TODO: Navigate to dashboard
+              // context.go('/dashboard');
+            },
+            onDismiss: () {
+              // TODO: Handle dismiss action
+            },
+          );
         },
       ),
       // Add more routes here as your app grows

--- a/lib/features/auth/presentation/pages/signup_success_screen.dart
+++ b/lib/features/auth/presentation/pages/signup_success_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/features/auth/presentation/widgets/signup_success_dialog.dart';
+
+/// SignupSuccessScreen displays the signup success dialog modal
+/// after successful email verification.
+///
+/// This screen shows a modal dialog with:
+/// - Success confirmation message
+/// - Celebration emoji icon
+/// - Action button to proceed to dashboard
+/// - Close button for dismissal
+/// - Smooth animations and responsive design
+class SignupSuccessScreen extends StatefulWidget {
+  /// Optional callback when user proceeds to dashboard
+  final VoidCallback? onProceedToDashboard;
+
+  /// Optional callback when dialog is dismissed
+  final VoidCallback? onDismiss;
+
+  const SignupSuccessScreen({
+    super.key,
+    this.onProceedToDashboard,
+    this.onDismiss,
+  });
+
+  @override
+  State<SignupSuccessScreen> createState() => _SignupSuccessScreenState();
+}
+
+class _SignupSuccessScreenState extends State<SignupSuccessScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Show the dialog immediately
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _showSignupSuccessDialog();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.lightBackground,
+      body: Container(
+        color: AppColors.lightBackground,
+      ),
+    );
+  }
+
+  /// Display the signup success dialog modal
+  void _showSignupSuccessDialog() {
+    showDialog(
+      context: context,
+      barrierDismissible: false, // Force user interaction with buttons
+      barrierColor: Colors.black.withValues(alpha: 0.5),
+      builder: (BuildContext context) {
+        return SignupSuccessDialog(
+          emoji: '🎉',
+          allowBackdropDismiss: false,
+          onDismiss: () {
+            widget.onDismiss?.call();
+            // Could navigate to another screen here
+          },
+          onProceedToDashboard: () {
+            widget.onProceedToDashboard?.call();
+            // Navigate to dashboard here
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/signup_success_dialog.dart
+++ b/lib/features/auth/presentation/widgets/signup_success_dialog.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+import 'package:zendvo/core/utils/size_config.dart';
+
+/// Reusable SignupSuccessDialog widget displayed as a confirmation modal
+/// after successful email verification.
+///
+/// Features:
+/// - Rounded corners and white background
+/// - Semi-transparent dark backdrop overlay
+/// - Celebration emoji icon in purple circle
+/// - Bold headline with success message
+/// - Body text with proper spacing and formatting
+/// - Close button (X) for dismissal
+/// - Full-width primary "Proceed to dashboard" button
+/// - Smooth fade-in and slide-up animations
+/// - Safe area and responsive design support
+class SignupSuccessDialog extends StatefulWidget {
+  /// Callback when the dialog is dismissed or action button is tapped
+  final VoidCallback? onDismiss;
+
+  /// Callback when "Proceed to dashboard" button is tapped
+  final VoidCallback? onProceedToDashboard;
+
+  /// Whether to allow dismissal via backdrop tap
+  final bool allowBackdropDismiss;
+
+  /// Emoji/icon to display in the circle
+  final String emoji;
+
+  const SignupSuccessDialog({
+    super.key,
+    this.onDismiss,
+    this.onProceedToDashboard,
+    this.allowBackdropDismiss = false,
+    this.emoji = '🎉',
+  });
+
+  @override
+  State<SignupSuccessDialog> createState() => _SignupSuccessDialogState();
+}
+
+class _SignupSuccessDialogState extends State<SignupSuccessDialog>
+    with TickerProviderStateMixin {
+  late AnimationController _fadeController;
+  late AnimationController _slideController;
+  late Animation<double> _fadeAnimation;
+  late Animation<Offset> _slideAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Fade animation controller
+    _fadeController = AnimationController(
+      duration: const Duration(milliseconds: 400),
+      vsync: this,
+    );
+
+    // Slide animation controller for celebration effect
+    _slideController = AnimationController(
+      duration: const Duration(milliseconds: 600),
+      vsync: this,
+    );
+
+    // Fade animation from 0 to 1
+    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _fadeController, curve: Curves.easeInOut),
+    );
+
+    // Slide animation from bottom to final position with ease
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0.0, 0.3),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(parent: _slideController, curve: Curves.easeOutCubic),
+    );
+
+    // Start animations
+    _fadeController.forward();
+    _slideController.forward();
+  }
+
+  @override
+  void dispose() {
+    _fadeController.dispose();
+    _slideController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    SizeConfig().init(context);
+
+    return FadeTransition(
+      opacity: _fadeAnimation,
+      child: SlideTransition(
+        position: _slideAnimation,
+        child: Dialog(
+          insetAnimationDuration: const Duration(milliseconds: 300),
+          insetAnimationCurve: Curves.easeOut,
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          child: GestureDetector(
+            onTap: widget.allowBackdropDismiss
+                ? () {
+                    _dismissDialog();
+                  }
+                : null,
+            child: Container(
+              color: Colors.transparent,
+              child: Center(
+                child: GestureDetector(
+                  onTap: () {}, // Prevent dismiss when tapping the modal
+                  child: _buildModalContent(context),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildModalContent(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: SingleChildScrollView(
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.15),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Close button (X) positioned at top-left
+                  Align(
+                    alignment: Alignment.topLeft,
+                    child: GestureDetector(
+                      onTap: _dismissDialog,
+                      child: Container(
+                        padding: const EdgeInsets.all(8),
+                        child: Icon(
+                          Icons.close,
+                          size: 24,
+                          color: AppColors.lightTextBody,
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: SizeConfig.getHeight(2)),
+
+                  // Emoji icon in purple circle
+                  Container(
+                    width: 80,
+                    height: 80,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: AppColors.primary.withValues(alpha: 0.15),
+                    ),
+                    child: Center(
+                      child: Text(
+                        widget.emoji,
+                        style: const TextStyle(fontSize: 40),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: SizeConfig.getHeight(3)),
+
+                  // Headline
+                  Text(
+                    AppStrings.signupSuccessTitle,
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.lightTextHeading,
+                      height: 1.3,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: SizeConfig.getHeight(2)),
+
+                  // Body text
+                  Text(
+                    AppStrings.signupSuccessMessage,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: AppColors.lightTextBody,
+                      height: 1.6,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: SizeConfig.getHeight(4)),
+
+                  // Proceed to dashboard button
+                  SizedBox(
+                    width: double.infinity,
+                    height: 48,
+                    child: ElevatedButton(
+                      onPressed: _proceedToDashboard,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.primary,
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        elevation: 0,
+                      ),
+                      child: Text(
+                        AppStrings.signupSuccessButton,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.5,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Dismiss the dialog with optional callback
+  void _dismissDialog() {
+    Navigator.of(context).pop();
+    widget.onDismiss?.call();
+  }
+
+  /// Proceed to dashboard with optional callback
+  void _proceedToDashboard() {
+    Navigator.of(context).pop();
+    widget.onProceedToDashboard?.call();
+  }
+}

--- a/lib/test_signup_success_dialog.dart
+++ b/lib/test_signup_success_dialog.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/features/auth/presentation/widgets/signup_success_dialog.dart';
+
+/// Test widget to verify the SignupSuccessDialog appearance and functionality
+void main() {
+  runApp(const SignupSuccessDialogTestApp());
+}
+
+class SignupSuccessDialogTestApp extends StatelessWidget {
+  const SignupSuccessDialogTestApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Signup Success Dialog Test',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF5E49E2),
+          primary: const Color(0xFF5E49E2),
+        ),
+        fontFamily: 'BR Firma',
+      ),
+      home: const SignupSuccessDialogTestPage(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+class SignupSuccessDialogTestPage extends StatelessWidget {
+  const SignupSuccessDialogTestPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text('Signup Success Dialog Test'),
+        elevation: 0,
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            showDialog(
+              context: context,
+              barrierDismissible: false,
+              barrierColor: Colors.black.withValues(alpha: 0.5),
+              builder: (BuildContext context) {
+                return SignupSuccessDialog(
+                  emoji: '🎉',
+                  allowBackdropDismiss: false,
+                  onDismiss: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Dialog dismissed')),
+                    );
+                  },
+                  onProceedToDashboard: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Proceeding to dashboard')),
+                    );
+                  },
+                );
+              },
+            );
+          },
+          child: const Text('Show Signup Success Dialog'),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -361,10 +361,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
I've built the reusable SignupSuccessDialog widget with smooth animations, emoji celebration icon, and proper navigation. Navigate to the signup success screen after email verification by calling context.go('/signup-success'). Closes #3

<img width="920" height="1059" alt="image" src="https://github.com/user-attachments/assets/c609b741-a0c1-4614-aab2-dcd17dbcd9d6" />
