### PR TITLE
Feat/auth screens

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -113,4 +113,10 @@ class AppStrings {
   static const String loginButton = "Login";
   static const String notRegisteredYet = "Not registered yet? ";
   static const String signUp = "Sign Up";
+
+  // Signup Success Modal
+  static const String signupSuccessTitle = "Signup successful";
+  static const String signupSuccessDescription =
+      "start receiving surprises from the people who matter.";
+  static const String signupSuccessCta = "Proceed to dashboard";
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:zendvo/features/auth/presentation/pages/create_new_password/create_new_password_screen.dart';
+import 'package:zendvo/features/auth/presentation/pages/dashboard/dashboard_screen.dart';
+import 'package:zendvo/features/auth/presentation/pages/forgot_password/forgot_password_screen.dart';
 import 'package:zendvo/features/auth/presentation/pages/login/login_screen.dart';
+import 'package:zendvo/features/auth/presentation/pages/register/register_screen.dart';
+import 'package:zendvo/features/auth/presentation/pages/verify_email/verify_email_screen.dart';
 
 class AppRouter {
   static final GoRouter router = GoRouter(
@@ -10,6 +15,35 @@ class AppRouter {
         path: '/login',
         name: 'login',
         builder: (context, state) => const LoginScreen(),
+      ),
+      GoRoute(
+        path: '/register',
+        name: 'register',
+        builder: (context, state) => const RegisterScreen(),
+      ),
+      GoRoute(
+        path: '/verify-email',
+        name: 'verify-email',
+        builder: (context, state) {
+          final email = state.uri.queryParameters['email'] ?? '';
+          final flow = state.uri.queryParameters['flow'] ?? 'register';
+          return VerifyEmailScreen(email: email, flow: flow);
+        },
+      ),
+      GoRoute(
+        path: '/forgot-password',
+        name: 'forgot-password',
+        builder: (context, state) => const ForgotPasswordScreen(),
+      ),
+      GoRoute(
+        path: '/create-new-password',
+        name: 'create-new-password',
+        builder: (context, state) => const CreateNewPasswordScreen(),
+      ),
+      GoRoute(
+        path: '/dashboard',
+        name: 'dashboard',
+        builder: (context, state) => const DashboardScreen(),
       ),
     ],
     errorBuilder: (context, state) => Scaffold(

--- a/lib/core/widgets/app_footer.dart
+++ b/lib/core/widgets/app_footer.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+
+/// Shared footer widget shown across auth screens.
+///
+/// Displays "Help · Terms & Conditions · Privacy Policy" links.
+class AppFooter extends StatelessWidget {
+  const AppFooter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = TextStyle(
+      fontSize: 12,
+      color: AppColors.getBodyTextColor(context).withValues(alpha: 0.5),
+    );
+
+    final separatorStyle = TextStyle(
+      fontSize: 12,
+      color: AppColors.getBodyTextColor(context).withValues(alpha: 0.3),
+    );
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        GestureDetector(
+          onTap: () {
+            // TODO: Open help
+          },
+          child: Text(AppStrings.help, style: textStyle),
+        ),
+        Text('  ·  ', style: separatorStyle),
+        GestureDetector(
+          onTap: () {
+            // TODO: Open terms
+          },
+          child: Text(AppStrings.terms, style: textStyle),
+        ),
+        Text('  ·  ', style: separatorStyle),
+        GestureDetector(
+          onTap: () {
+            // TODO: Open privacy policy
+          },
+          child: Text(AppStrings.privacy, style: textStyle),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/bloc/verify_email/verify_email_bloc.dart
+++ b/lib/features/auth/presentation/bloc/verify_email/verify_email_bloc.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'verify_email_event.dart';
+import 'verify_email_state.dart';
+
+class VerifyEmailBloc extends Bloc<VerifyEmailEvent, VerifyEmailState> {
+  Timer? _timer;
+
+  VerifyEmailBloc() : super(const VerifyEmailFormState()) {
+    on<VerifyEmailOtpChanged>(_onOtpChanged);
+    on<VerifyEmailSubmitted>(_onSubmitted);
+    on<VerifyEmailResendOtp>(_onResendOtp);
+    on<VerifyEmailTimerTick>(_onTimerTick);
+
+    _startTimer();
+  }
+
+  VerifyEmailFormState get _form =>
+      state is VerifyEmailFormState
+          ? state as VerifyEmailFormState
+          : const VerifyEmailFormState();
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      add(VerifyEmailTimerTick());
+    });
+  }
+
+  void _onTimerTick(
+    VerifyEmailTimerTick event,
+    Emitter<VerifyEmailState> emit,
+  ) {
+    if (_form.secondsRemaining > 0) {
+      emit(_form.copyWith(secondsRemaining: _form.secondsRemaining - 1));
+    } else {
+      _timer?.cancel();
+    }
+  }
+
+  void _onOtpChanged(
+    VerifyEmailOtpChanged event,
+    Emitter<VerifyEmailState> emit,
+  ) {
+    emit(_form.copyWith(otp: event.otp, hasError: false));
+  }
+
+  Future<void> _onSubmitted(
+    VerifyEmailSubmitted event,
+    Emitter<VerifyEmailState> emit,
+  ) async {
+    if (!_form.isOtpComplete) return;
+
+    emit(VerifyEmailLoading());
+
+    try {
+      // TODO: Replace with real OTP verification API call
+      await Future.delayed(const Duration(seconds: 2));
+
+      emit(VerifyEmailSuccess());
+    } catch (e) {
+      emit(VerifyEmailError(e.toString().replaceAll('Exception: ', '')));
+    }
+  }
+
+  void _onResendOtp(
+    VerifyEmailResendOtp event,
+    Emitter<VerifyEmailState> emit,
+  ) {
+    if (!_form.canResend) return;
+
+    // TODO: Replace with real resend OTP API call
+    emit(_form.copyWith(secondsRemaining: 59, otp: '', hasError: false));
+    _startTimer();
+  }
+
+  @override
+  Future<void> close() {
+    _timer?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/auth/presentation/bloc/verify_email/verify_email_event.dart
+++ b/lib/features/auth/presentation/bloc/verify_email/verify_email_event.dart
@@ -1,0 +1,23 @@
+import 'package:equatable/equatable.dart';
+
+abstract class VerifyEmailEvent extends Equatable {
+  const VerifyEmailEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class VerifyEmailOtpChanged extends VerifyEmailEvent {
+  final String otp;
+
+  const VerifyEmailOtpChanged(this.otp);
+
+  @override
+  List<Object?> get props => [otp];
+}
+
+class VerifyEmailSubmitted extends VerifyEmailEvent {}
+
+class VerifyEmailResendOtp extends VerifyEmailEvent {}
+
+class VerifyEmailTimerTick extends VerifyEmailEvent {}

--- a/lib/features/auth/presentation/bloc/verify_email/verify_email_state.dart
+++ b/lib/features/auth/presentation/bloc/verify_email/verify_email_state.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+
+abstract class VerifyEmailState extends Equatable {
+  const VerifyEmailState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class VerifyEmailFormState extends VerifyEmailState {
+  final String otp;
+  final int secondsRemaining;
+  final bool hasError;
+  final String? errorMessage;
+
+  const VerifyEmailFormState({
+    this.otp = '',
+    this.secondsRemaining = 59,
+    this.hasError = false,
+    this.errorMessage,
+  });
+
+  bool get canResend => secondsRemaining <= 0;
+  bool get isOtpComplete => otp.length == 6;
+
+  VerifyEmailFormState copyWith({
+    String? otp,
+    int? secondsRemaining,
+    bool? hasError,
+    String? errorMessage,
+  }) {
+    return VerifyEmailFormState(
+      otp: otp ?? this.otp,
+      secondsRemaining: secondsRemaining ?? this.secondsRemaining,
+      hasError: hasError ?? this.hasError,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [otp, secondsRemaining, hasError, errorMessage];
+}
+
+class VerifyEmailLoading extends VerifyEmailState {}
+
+class VerifyEmailSuccess extends VerifyEmailState {}
+
+class VerifyEmailError extends VerifyEmailState {
+  final String message;
+
+  const VerifyEmailError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/auth/presentation/pages/dashboard/dashboard_screen.dart
+++ b/lib/features/auth/presentation/pages/dashboard/dashboard_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_spacing.dart';
+
+/// Placeholder dashboard screen.
+///
+/// Serves as the navigation destination after successful signup.
+/// This will be replaced with the full dashboard implementation.
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.getBackgroundColor(context),
+      body: SafeArea(
+        child: Padding(
+          padding: AppSpacing.screenPadding,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 16),
+
+              // Zendvo branding
+              Text(
+                'Zendvo',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.primary,
+                ),
+              ),
+
+              const Spacer(),
+
+              // Welcome message
+              Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        color: AppColors.primaryLight,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Center(
+                        child: Text('🎁', style: TextStyle(fontSize: 36)),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.l),
+                    Text(
+                      'Welcome to Zendvo!',
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                        color: AppColors.getHeadingTextColor(context),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    Text(
+                      'Your dashboard is being built.',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: AppColors.getBodyTextColor(context),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const Spacer(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/login/login_screen.dart
+++ b/lib/features/auth/presentation/pages/login/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zendvo/core/constants/app_colors.dart';
 import 'package:zendvo/core/constants/app_spacing.dart';
 import 'package:zendvo/core/constants/app_strings.dart';
@@ -33,13 +34,7 @@ class _LoginView extends StatelessWidget {
 
   void _handleStateChanges(BuildContext context, LoginState state) {
     if (state is LoginSuccess) {
-      // TODO: Navigate to home/dashboard screen
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Login successful!'),
-          backgroundColor: AppColors.success,
-        ),
-      );
+      context.go('/dashboard');
     } else if (state is LoginError) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/features/auth/presentation/pages/verify_email/verify_email_screen.dart
+++ b/lib/features/auth/presentation/pages/verify_email/verify_email_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_spacing.dart';
+import 'package:zendvo/core/utils/size_config.dart';
+import 'package:zendvo/core/widgets/app_footer.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_bloc.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_state.dart';
+import 'package:zendvo/features/auth/presentation/widgets/signup_success_modal.dart';
+import 'widgets/verify_email_actions.dart';
+import 'widgets/verify_email_header.dart';
+import 'widgets/verify_email_otp_section.dart';
+import 'widgets/verify_email_title_section.dart';
+
+/// Email verification (OTP) screen.
+///
+/// Shared between the registration and forgot-password flows.
+/// The [email] parameter is used to display the masked email.
+/// The [flow] parameter ('register' or 'forgot-password') determines
+/// button labels and post-verification navigation.
+class VerifyEmailScreen extends StatelessWidget {
+  final String email;
+  final String flow;
+
+  const VerifyEmailScreen({
+    super.key,
+    required this.email,
+    required this.flow,
+  });
+
+  /// Masks an email like "john123@gmail.com" → "jo***3@gmail.com"
+  String _maskEmail(String email) {
+    final parts = email.split('@');
+    if (parts.length != 2 || parts[0].length < 3) return email;
+
+    final name = parts[0];
+    final masked =
+        '${name.substring(0, 2)}***${name.substring(name.length - 1)}';
+    return '$masked@${parts[1]}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => VerifyEmailBloc(),
+      child: _VerifyEmailView(
+        maskedEmail: _maskEmail(email),
+        flow: flow,
+      ),
+    );
+  }
+}
+
+class _VerifyEmailView extends StatelessWidget {
+  final String maskedEmail;
+  final String flow;
+
+  const _VerifyEmailView({
+    required this.maskedEmail,
+    required this.flow,
+  });
+
+  void _handleStateChanges(BuildContext context, VerifyEmailState state) {
+    if (state is VerifyEmailSuccess) {
+      if (flow == 'register') {
+        SignupSuccessModal.show(context);
+      } else {
+        context.push('/create-new-password');
+      }
+    } else if (state is VerifyEmailError) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(state.message),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    SizeConfig().init(context);
+
+    return Scaffold(
+      backgroundColor: AppColors.getBackgroundColor(context),
+      body: SafeArea(
+        child: BlocListener<VerifyEmailBloc, VerifyEmailState>(
+          listener: _handleStateChanges,
+          child: Padding(
+            padding: AppSpacing.screenPadding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: SizeConfig.getHeight(2)),
+                const VerifyEmailHeader(),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                VerifyEmailTitleSection(maskedEmail: maskedEmail),
+                SizedBox(height: SizeConfig.getHeight(3)),
+                const VerifyEmailOtpSection(),
+                const Spacer(),
+                VerifyEmailActions(flow: flow),
+                SizedBox(height: SizeConfig.getHeight(2)),
+                const AppFooter(),
+                SizedBox(height: SizeConfig.getHeight(2)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_actions.dart
+++ b/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_actions.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+import 'package:zendvo/core/widgets/app_button.dart';
+import 'package:zendvo/core/widgets/help_dialog/help_dialog.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_bloc.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_event.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_state.dart';
+
+/// Bottom action section with verify/create account button and help link.
+class VerifyEmailActions extends StatelessWidget {
+  /// The flow context determines the button label:
+  /// - 'register' → "Create Account"
+  /// - 'forgot-password' → "Verify"
+  final String flow;
+
+  const VerifyEmailActions({super.key, required this.flow});
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonText = flow == 'register'
+        ? AppStrings.createAccountButton
+        : AppStrings.verifyButton;
+
+    return Column(
+      children: [
+        BlocBuilder<VerifyEmailBloc, VerifyEmailState>(
+          builder: (context, state) {
+            final isComplete = state is VerifyEmailFormState &&
+                state.isOtpComplete;
+            return AppButton(
+              text: buttonText,
+              isLoading: state is VerifyEmailLoading,
+              onPressed: isComplete && state is! VerifyEmailLoading
+                  ? () {
+                      context
+                          .read<VerifyEmailBloc>()
+                          .add(VerifyEmailSubmitted());
+                    }
+                  : null,
+            );
+          },
+        ),
+        const SizedBox(height: 16),
+        GestureDetector(
+          onTap: () => HelpDialog.show(context),
+          child: Text(
+            AppStrings.lowEmailAction,
+            style: TextStyle(
+              fontSize: 14,
+              color: AppColors.primary,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_header.dart
+++ b/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_header.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+
+/// Zendvo branding header for the verify email screen.
+class VerifyEmailHeader extends StatelessWidget {
+  const VerifyEmailHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        GestureDetector(
+          onTap: () => Navigator.of(context).pop(),
+          child: Icon(
+            Icons.arrow_back_ios,
+            size: 20,
+            color: AppColors.getHeadingTextColor(context),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: AppColors.primary,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Center(
+            child: Icon(Icons.vignette, color: Colors.white, size: 24),
+          ),
+        ),
+        const SizedBox(width: 12),
+        const Text(
+          "Zendvo",
+          style: TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+            color: AppColors.lightTextHeading,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_otp_section.dart
+++ b/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_otp_section.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_bloc.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_event.dart';
+import 'package:zendvo/features/auth/presentation/bloc/verify_email/verify_email_state.dart';
+import 'package:zendvo/features/auth/presentation/widgets/otp_input_widget.dart';
+
+/// OTP input section with resend countdown timer.
+class VerifyEmailOtpSection extends StatelessWidget {
+  const VerifyEmailOtpSection({super.key});
+
+  String _formatTime(int seconds) {
+    final minutes = seconds ~/ 60;
+    final secs = seconds % 60;
+    return '$minutes:${secs.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<VerifyEmailBloc, VerifyEmailState>(
+      builder: (context, state) {
+        final formState = state is VerifyEmailFormState
+            ? state
+            : const VerifyEmailFormState();
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            OtpInputWidget(
+              length: 6,
+              hasError: formState.hasError,
+              onCompleted: (otp) {
+                context
+                    .read<VerifyEmailBloc>()
+                    .add(VerifyEmailOtpChanged(otp));
+              },
+            ),
+            const SizedBox(height: 16),
+            GestureDetector(
+              onTap: formState.canResend
+                  ? () {
+                      context
+                          .read<VerifyEmailBloc>()
+                          .add(VerifyEmailResendOtp());
+                    }
+                  : null,
+              child: RichText(
+                text: TextSpan(
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: formState.canResend
+                        ? AppColors.primary
+                        : AppColors.getBodyTextColor(context),
+                    fontFamily: 'BR Firma',
+                  ),
+                  children: [
+                    TextSpan(
+                      text: AppStrings.resendCode,
+                      style: TextStyle(
+                        color: AppColors.primary,
+                        fontWeight: formState.canResend
+                            ? FontWeight.w600
+                            : FontWeight.normal,
+                      ),
+                    ),
+                    if (!formState.canResend)
+                      TextSpan(
+                        text: _formatTime(formState.secondsRemaining),
+                        style: TextStyle(
+                          color: AppColors.getBodyTextColor(context),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_title_section.dart
+++ b/lib/features/auth/presentation/pages/verify_email/widgets/verify_email_title_section.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+
+/// Title section for the verify email screen.
+///
+/// Displays the title and a subtitle with the user's masked email address.
+class VerifyEmailTitleSection extends StatelessWidget {
+  final String maskedEmail;
+
+  const VerifyEmailTitleSection({super.key, required this.maskedEmail});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          AppStrings.verifyEmailTitle,
+          style: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.bold,
+            color: AppColors.getHeadingTextColor(context),
+          ),
+        ),
+        const SizedBox(height: 8),
+        RichText(
+          text: TextSpan(
+            style: TextStyle(
+              fontSize: 14,
+              color: AppColors.getBodyTextColor(context),
+              height: 1.5,
+              fontFamily: 'BR Firma',
+            ),
+            children: [
+              const TextSpan(text: AppStrings.verifyEmailSubtitle),
+              TextSpan(
+                text: maskedEmail,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/signup_success_modal.dart
+++ b/lib/features/auth/presentation/widgets/signup_success_modal.dart
@@ -1,0 +1,143 @@
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_spacing.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+import 'package:zendvo/core/widgets/app_button.dart';
+
+/// Signup success confirmation modal.
+///
+/// Shown after a user successfully registers. Presents a celebratory
+/// party-popper icon, success title/description, and a CTA button
+/// that navigates to the dashboard.
+///
+/// Usage:
+/// ```dart
+/// SignupSuccessModal.show(context);
+/// ```
+class SignupSuccessModal extends StatelessWidget {
+  const SignupSuccessModal({super.key});
+
+  /// Convenience method to display the modal as a dialog overlay.
+  static void show(BuildContext context) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const SignupSuccessModal(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.l),
+      child: Container(
+        padding: const EdgeInsets.all(AppSpacing.l),
+        decoration: BoxDecoration(
+          color: AppColors.getBackgroundColor(context),
+          borderRadius: BorderRadius.circular(AppSpacing.xl),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Close button row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                IconButton(
+                  onPressed: () => Navigator.pop(context),
+                  icon: Icon(
+                    Icons.close,
+                    color:
+                        AppColors.getBodyTextColor(context).withOpacity(0.6),
+                    size: 20,
+                  ),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: AppSpacing.s),
+
+            // Divider
+            Divider(
+              color:
+                  AppColors.getInactiveBorderColor(context).withOpacity(0.5),
+              thickness: 1,
+              height: 1,
+            ),
+
+            const SizedBox(height: AppSpacing.xl),
+
+            // Party popper icon in purple circle
+            _buildCelebrationIcon(),
+
+            const SizedBox(height: AppSpacing.xl),
+
+            // Title
+            Text(
+              AppStrings.signupSuccessTitle,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: AppColors.getHeadingTextColor(context),
+              ),
+              textAlign: TextAlign.center,
+            ),
+
+            const SizedBox(height: AppSpacing.s),
+
+            // Description
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
+              child: Text(
+                AppStrings.signupSuccessDescription,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: AppColors.getBodyTextColor(context),
+                  height: 1.5,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+
+            const SizedBox(height: AppSpacing.xl),
+
+            // CTA button
+            AppButton(
+              text: AppStrings.signupSuccessCta,
+              onPressed: () {
+                Navigator.pop(context); // dismiss modal
+                context.go('/dashboard'); // navigate to dashboard
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the purple circle containing the party popper emoji,
+  /// matching the Figma design (66×66 circle with 8px primaryLight border).
+  Widget _buildCelebrationIcon() {
+    return Container(
+      width: 66,
+      height: 66,
+      decoration: BoxDecoration(
+        color: AppColors.primary,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: AppColors.primaryLight,
+          width: 8,
+        ),
+      ),
+      child: const Center(
+        child: Text('🎉', style: TextStyle(fontSize: 28)),
+      ),
+    );
+  }
+}


### PR DESCRIPTION


This PR implements the complete **Forgot Password → OTP Verification → Create New Password** flow, along with the full **Registration → OTP Verification → Signup Success** flow.

Closes #30, closes #31, closes #32, closes #33, closes #34

#### What was implemented

| Screen | Route | Issue |
|--------|-------|-------|
| Forgot Password | `/forgot-password` | #30 |
| Verify Email (OTP) | `/verify-email` | #31 |
| HelpDialog Integration | — | #32 |
| Create New Password | `/create-new-password` | #33 |
| Signup Success Modal | — | #34 |
| Registration | `/register` | — |

#### Architecture

- **BLoC pattern** for all screens (`ForgotPasswordBloc`, `VerifyEmailBloc`, `CreateNewPasswordBloc`, `RegisterBloc`) with Event/State separation using `equatable`
- **GoRouter** for navigation with query parameters (`?email=...&flow=register|forgot-password`)
- Reuses existing `AppTextField`, `AppButton`, `OtpInputWidget`, and `HelpDialog` widgets
- Widget decomposition follows the same pattern as `LoginScreen` (header, title, form, footer)

#### Key features

-  **Password complexity validation** — uppercase, lowercase, number, special character checks via regex
-  **59-second OTP countdown timer** with resend capability
-  **Email masking** — `john123@gmail.com` → `jo***3@gmail.com`
-  **Back navigation** on all inner screens
-  **Signup success modal** with party popper icon and dashboard navigation
-  **Phone number input** 

drive link of the screen recording : https://drive.google.com/file/d/1NMLBH6xzDeP0IoPDgCVcfgoOLVkcIZBy/view?usp=sharing
