### PR TITLE
feat: add create new password screen

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zendvo/features/auth/presentation/pages/login/login_screen.dart';
+import 'package:zendvo/features/auth/presentation/pages/create_new_password/create_new_password_screen.dart';
 
 class AppRouter {
   static final GoRouter router = GoRouter(
@@ -10,6 +11,11 @@ class AppRouter {
         path: '/login',
         name: 'login',
         builder: (context, state) => const LoginScreen(),
+      ),
+      GoRoute(
+        path: '/create-new-password',
+        name: 'create-new-password',
+        builder: (context, state) => const CreateNewPasswordScreen(),
       ),
     ],
     errorBuilder: (context, state) => Scaffold(

--- a/lib/features/auth/presentation/bloc/create_new_password/create_new_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/create_new_password/create_new_password_bloc.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'create_new_password_event.dart';
+import 'create_new_password_state.dart';
+
+class CreateNewPasswordBloc
+    extends Bloc<CreateNewPasswordEvent, CreateNewPasswordState> {
+  CreateNewPasswordBloc() : super(const CreateNewPasswordFormState()) {
+    on<PasswordChanged>(_onPasswordChanged);
+    on<ConfirmPasswordChanged>(_onConfirmPasswordChanged);
+    on<CreateNewPasswordSubmitted>(_onSubmitted);
+  }
+
+  CreateNewPasswordFormState get _form =>
+      state is CreateNewPasswordFormState
+          ? state as CreateNewPasswordFormState
+          : const CreateNewPasswordFormState();
+
+  void _onPasswordChanged(
+    PasswordChanged event,
+    Emitter<CreateNewPasswordState> emit,
+  ) {
+    emit(_form.copyWith(password: event.password));
+  }
+
+  void _onConfirmPasswordChanged(
+    ConfirmPasswordChanged event,
+    Emitter<CreateNewPasswordState> emit,
+  ) {
+    emit(_form.copyWith(confirmPassword: event.confirmPassword));
+  }
+
+  Future<void> _onSubmitted(
+    CreateNewPasswordSubmitted event,
+    Emitter<CreateNewPasswordState> emit,
+  ) async {
+    if (!_form.isFormValid) return;
+
+    emit(CreateNewPasswordLoading());
+
+    try {
+      // TODO: Replace with real password reset repository call
+      await Future.delayed(const Duration(seconds: 2));
+      emit(CreateNewPasswordSuccess());
+    } catch (e) {
+      emit(CreateNewPasswordError(e.toString().replaceAll('Exception: ', '')));
+    }
+  }
+}

--- a/lib/features/auth/presentation/bloc/create_new_password/create_new_password_event.dart
+++ b/lib/features/auth/presentation/bloc/create_new_password/create_new_password_event.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+abstract class CreateNewPasswordEvent extends Equatable {
+  const CreateNewPasswordEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class PasswordChanged extends CreateNewPasswordEvent {
+  final String password;
+  const PasswordChanged(this.password);
+
+  @override
+  List<Object?> get props => [password];
+}
+
+class ConfirmPasswordChanged extends CreateNewPasswordEvent {
+  final String confirmPassword;
+  const ConfirmPasswordChanged(this.confirmPassword);
+
+  @override
+  List<Object?> get props => [confirmPassword];
+}
+
+class CreateNewPasswordSubmitted extends CreateNewPasswordEvent {}

--- a/lib/features/auth/presentation/bloc/create_new_password/create_new_password_state.dart
+++ b/lib/features/auth/presentation/bloc/create_new_password/create_new_password_state.dart
@@ -1,0 +1,52 @@
+import 'package:equatable/equatable.dart';
+
+abstract class CreateNewPasswordState extends Equatable {
+  const CreateNewPasswordState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class CreateNewPasswordFormState extends CreateNewPasswordState {
+  final String password;
+  final String confirmPassword;
+
+  const CreateNewPasswordFormState({
+    this.password = '',
+    this.confirmPassword = '',
+  });
+
+  static final _passwordRegex = RegExp(
+    r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$&*~%^()\-_=+\[\]{}|;:,.<>?]).{8,}$',
+  );
+
+  bool get isPasswordValid => _passwordRegex.hasMatch(password);
+  bool get doPasswordsMatch =>
+      password.isNotEmpty && password == confirmPassword;
+  bool get isFormValid => isPasswordValid && doPasswordsMatch;
+
+  CreateNewPasswordFormState copyWith({
+    String? password,
+    String? confirmPassword,
+  }) {
+    return CreateNewPasswordFormState(
+      password: password ?? this.password,
+      confirmPassword: confirmPassword ?? this.confirmPassword,
+    );
+  }
+
+  @override
+  List<Object?> get props => [password, confirmPassword];
+}
+
+class CreateNewPasswordLoading extends CreateNewPasswordState {}
+
+class CreateNewPasswordSuccess extends CreateNewPasswordState {}
+
+class CreateNewPasswordError extends CreateNewPasswordState {
+  final String message;
+  const CreateNewPasswordError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/auth/presentation/pages/create_new_password/create_new_password_screen.dart
+++ b/lib/features/auth/presentation/pages/create_new_password/create_new_password_screen.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_spacing.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+import 'package:zendvo/core/utils/size_config.dart';
+import 'package:zendvo/core/widgets/app_button.dart';
+import 'package:zendvo/core/widgets/app_text_field.dart';
+import 'package:zendvo/features/auth/presentation/bloc/create_new_password/create_new_password_bloc.dart';
+import 'package:zendvo/features/auth/presentation/bloc/create_new_password/create_new_password_event.dart';
+import 'package:zendvo/features/auth/presentation/bloc/create_new_password/create_new_password_state.dart';
+import 'package:zendvo/features/auth/presentation/pages/login/widgets/login_footer.dart';
+import 'package:zendvo/features/auth/presentation/pages/login/widgets/login_header.dart';
+
+class CreateNewPasswordScreen extends StatelessWidget {
+  const CreateNewPasswordScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => CreateNewPasswordBloc(),
+      child: const _CreateNewPasswordView(),
+    );
+  }
+}
+
+class _CreateNewPasswordView extends StatelessWidget {
+  const _CreateNewPasswordView();
+
+  void _handleStateChanges(
+    BuildContext context,
+    CreateNewPasswordState state,
+  ) {
+    if (state is CreateNewPasswordSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Password created successfully!'),
+          backgroundColor: AppColors.success,
+        ),
+      );
+      context.go('/login');
+    } else if (state is CreateNewPasswordError) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(state.message),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    SizeConfig().init(context);
+
+    return Scaffold(
+      backgroundColor: AppColors.getBackgroundColor(context),
+      body: SafeArea(
+        child: BlocListener<CreateNewPasswordBloc, CreateNewPasswordState>(
+          listener: _handleStateChanges,
+          child: SingleChildScrollView(
+            padding: AppSpacing.screenPadding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: SizeConfig.getHeight(2)),
+                const LoginHeader(),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                _TitleSection(),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                const _PasswordForm(),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                BlocBuilder<CreateNewPasswordBloc, CreateNewPasswordState>(
+                  builder: (context, state) {
+                    final isValid =
+                        state is CreateNewPasswordFormState &&
+                        state.isFormValid;
+                    return AppButton(
+                      text: AppStrings.createNewPasswordButton,
+                      isLoading: state is CreateNewPasswordLoading,
+                      onPressed: isValid
+                          ? () => context
+                              .read<CreateNewPasswordBloc>()
+                              .add(CreateNewPasswordSubmitted())
+                          : null,
+                    );
+                  },
+                ),
+                SizedBox(height: SizeConfig.getHeight(3)),
+                const LoginFooter(),
+                SizedBox(height: SizeConfig.getHeight(2)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TitleSection extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          AppStrings.createNewPasswordTitle,
+          style: TextStyle(
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+            color: AppColors.lightTextHeading,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          AppStrings.createNewPasswordSubtitle,
+          style: TextStyle(
+            fontSize: 16,
+            color: AppColors.lightTextBody.withValues(alpha: 0.8),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PasswordForm extends StatefulWidget {
+  const _PasswordForm();
+
+  @override
+  State<_PasswordForm> createState() => _PasswordFormState();
+}
+
+class _PasswordFormState extends State<_PasswordForm> {
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppTextField(
+          label: AppStrings.enterNewPasswordLabel,
+          isPassword: true,
+          controller: _passwordController,
+          onChanged: (value) =>
+              context.read<CreateNewPasswordBloc>().add(PasswordChanged(value)),
+        ),
+        SizedBox(height: SizeConfig.getHeight(1.5)),
+        const _PasswordRequirements(),
+        SizedBox(height: SizeConfig.getHeight(3)),
+        AppTextField(
+          label: AppStrings.confirmPasswordLabel,
+          isPassword: true,
+          controller: _confirmController,
+          onChanged: (value) => context
+              .read<CreateNewPasswordBloc>()
+              .add(ConfirmPasswordChanged(value)),
+        ),
+      ],
+    );
+  }
+}
+
+class _PasswordRequirements extends StatelessWidget {
+  const _PasswordRequirements();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<CreateNewPasswordBloc, CreateNewPasswordState>(
+      builder: (context, state) {
+        final password =
+            state is CreateNewPasswordFormState ? state.password : '';
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _RequirementRow(
+              label: 'At least 8 characters',
+              met: password.length >= 8,
+            ),
+            _RequirementRow(
+              label: 'One uppercase letter',
+              met: password.contains(RegExp(r'[A-Z]')),
+            ),
+            _RequirementRow(
+              label: 'One lowercase letter',
+              met: password.contains(RegExp(r'[a-z]')),
+            ),
+            _RequirementRow(
+              label: 'One number',
+              met: password.contains(RegExp(r'\d')),
+            ),
+            _RequirementRow(
+              label: 'One special character',
+              met: password.contains(
+                RegExp(r'[!@#\$&*~%^()\-_=+\[\]{}|;:,.<>?]'),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _RequirementRow extends StatelessWidget {
+  final String label;
+  final bool met;
+
+  const _RequirementRow({required this.label, required this.met});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Icon(
+            met ? Icons.check_circle : Icons.radio_button_unchecked,
+            size: 16,
+            color: met ? AppColors.success : AppColors.lightTextBody,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              color: met ? AppColors.success : AppColors.lightTextBody,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Implements the Create New Password screen (post-OTP verification step).

## Changes
- **BLoC** — `CreateNewPasswordEvent`, `CreateNewPasswordState`, `CreateNewPasswordBloc` under `bloc/create_new_password/`
- **Screen** — `create_new_password_screen.dart` with:
  - Reused `LoginHeader` and `LoginFooter`
  - Two obscured `AppTextField(isPassword: true)` fields
  - Live password requirements checklist (8+ chars, uppercase, lowercase, number, special char)
  - `AppButton` disabled until both fields pass validation and match
  - Navigates to `/login` on success
- **Router** — `/create-new-password` route registered in `app_router.dart`

## Tested
- Button remains disabled until all complexity rules are met and passwords match
- On submit navigates back to login screen       closes #33 