### PR TITLE
feat(auth): implement Forgot Password screen and Bloc flow

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:zendvo/features/auth/presentation/pages/forgot_password/forgot_password_screen.dart';
 import 'package:zendvo/features/auth/presentation/pages/login/login_screen.dart';
 
 class AppRouter {
@@ -10,6 +11,20 @@ class AppRouter {
         path: '/login',
         name: 'login',
         builder: (context, state) => const LoginScreen(),
+      ),
+      GoRoute(
+        path: '/forgot-password',
+        name: 'forgot-password',
+        builder: (context, state) => const ForgotPasswordScreen(),
+      ),
+      GoRoute(
+        path: '/verify-email',
+        name: 'verify-email',
+        builder: (context, state) => const Scaffold(
+          body: Center(
+            child: Text('Verify Email Screen (Placeholder)'),
+          ),
+        ),
       ),
     ],
     errorBuilder: (context, state) => Scaffold(

--- a/lib/features/auth/presentation/bloc/forgot_password/forgot_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/forgot_password/forgot_password_bloc.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'forgot_password_event.dart';
+import 'forgot_password_state.dart';
+
+class ForgotPasswordBloc extends Bloc<ForgotPasswordEvent, ForgotPasswordState> {
+  ForgotPasswordBloc() : super(const ForgotPasswordFormState()) {
+    on<ForgotPasswordEmailChanged>(_onEmailChanged);
+    on<ForgotPasswordSubmitted>(_onSubmitted);
+  }
+
+  ForgotPasswordFormState get _form => state is ForgotPasswordFormState
+      ? state as ForgotPasswordFormState
+      : const ForgotPasswordFormState();
+
+  void _onEmailChanged(
+    ForgotPasswordEmailChanged event,
+    Emitter<ForgotPasswordState> emit,
+  ) {
+    emit(_form.copyWith(email: event.email));
+  }
+
+  void _onSubmitted(
+    ForgotPasswordSubmitted event,
+    Emitter<ForgotPasswordState> emit,
+  ) {
+    if (!_form.isEmailValid) return;
+
+    emit(ForgotPasswordLoading());
+    // TODO: Replace with repository call
+    emit(ForgotPasswordSuccess());
+  }
+}

--- a/lib/features/auth/presentation/bloc/forgot_password/forgot_password_event.dart
+++ b/lib/features/auth/presentation/bloc/forgot_password/forgot_password_event.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+abstract class ForgotPasswordEvent extends Equatable {
+  const ForgotPasswordEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ForgotPasswordEmailChanged extends ForgotPasswordEvent {
+  final String email;
+
+  const ForgotPasswordEmailChanged(this.email);
+
+  @override
+  List<Object?> get props => [email];
+}
+
+class ForgotPasswordSubmitted extends ForgotPasswordEvent {}

--- a/lib/features/auth/presentation/bloc/forgot_password/forgot_password_state.dart
+++ b/lib/features/auth/presentation/bloc/forgot_password/forgot_password_state.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+
+abstract class ForgotPasswordState extends Equatable {
+  const ForgotPasswordState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ForgotPasswordFormState extends ForgotPasswordState {
+  final String email;
+
+  const ForgotPasswordFormState({
+    this.email = '',
+  });
+
+  ForgotPasswordFormState copyWith({
+    String? email,
+  }) {
+    return ForgotPasswordFormState(
+      email: email ?? this.email,
+    );
+  }
+
+  bool get isEmailValid =>
+      email.isNotEmpty &&
+      RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(email);
+
+  @override
+  List<Object?> get props => [email];
+}
+
+class ForgotPasswordLoading extends ForgotPasswordState {}
+
+class ForgotPasswordSuccess extends ForgotPasswordState {}
+
+class ForgotPasswordError extends ForgotPasswordState {
+  final String message;
+
+  const ForgotPasswordError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/auth/presentation/pages/forgot_password/forgot_password_screen.dart
+++ b/lib/features/auth/presentation/pages/forgot_password/forgot_password_screen.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zendvo/core/constants/app_colors.dart';
+import 'package:zendvo/core/constants/app_spacing.dart';
+import 'package:zendvo/core/constants/app_strings.dart';
+import 'package:zendvo/core/utils/size_config.dart';
+import 'package:zendvo/core/widgets/app_button.dart';
+import 'package:zendvo/core/widgets/app_text_field.dart';
+import 'package:zendvo/features/auth/presentation/bloc/forgot_password/forgot_password_bloc.dart';
+import 'package:zendvo/features/auth/presentation/bloc/forgot_password/forgot_password_event.dart';
+import 'package:zendvo/features/auth/presentation/bloc/forgot_password/forgot_password_state.dart';
+import 'package:zendvo/features/auth/presentation/widgets/auth_header.dart';
+
+/// Screen allowing users to request a password reset code.
+class ForgotPasswordScreen extends StatelessWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => ForgotPasswordBloc(),
+      child: const _ForgotPasswordView(),
+    );
+  }
+}
+
+class _ForgotPasswordView extends StatefulWidget {
+  const _ForgotPasswordView();
+
+  @override
+  State<_ForgotPasswordView> createState() => _ForgotPasswordViewState();
+}
+
+class _ForgotPasswordViewState extends State<_ForgotPasswordView> {
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _handleStateChanges(BuildContext context, ForgotPasswordState state) {
+    if (state is ForgotPasswordSuccess) {
+      context.go('/verify-email');
+    } else if (state is ForgotPasswordError) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(state.message),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    SizeConfig().init(context);
+
+    return Scaffold(
+      backgroundColor: AppColors.getBackgroundColor(context),
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(
+            Icons.arrow_back,
+            color: AppColors.getHeadingTextColor(context),
+          ),
+          onPressed: () {
+            context.pop();
+          },
+        ),
+      ),
+      body: SafeArea(
+        child: BlocListener<ForgotPasswordBloc, ForgotPasswordState>(
+          listener: _handleStateChanges,
+          child: SingleChildScrollView(
+            padding: AppSpacing.screenPadding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: SizeConfig.getHeight(2)),
+                const AuthHeader(),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                Text(
+                  AppStrings.forgotPasswordTitle,
+                  style: TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.getHeadingTextColor(context),
+                  ),
+                ),
+                SizedBox(height: SizeConfig.getHeight(1.5)),
+                Text(
+                  AppStrings.forgotPasswordSubtitle,
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: AppColors.getBodyTextColor(context).withOpacity(0.8),
+                    height: 1.4,
+                  ),
+                ),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                AppTextField(
+                  label: AppStrings.emailAddressLabel,
+                  hintText: AppStrings.emailAddressPlaceholder,
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  onChanged: (value) {
+                    context
+                        .read<ForgotPasswordBloc>()
+                        .add(ForgotPasswordEmailChanged(value));
+                  },
+                ),
+                SizedBox(height: SizeConfig.getHeight(4)),
+                BlocBuilder<ForgotPasswordBloc, ForgotPasswordState>(
+                  builder: (context, state) {
+                    final isFormValid =
+                        state is ForgotPasswordFormState && state.isEmailValid;
+                    final isLoading = state is ForgotPasswordLoading;
+
+                    return AppButton(
+                      text: AppStrings.continueButton,
+                      isLoading: isLoading,
+                      onPressed: isFormValid && !isLoading
+                          ? () {
+                              context
+                                  .read<ForgotPasswordBloc>()
+                                  .add(ForgotPasswordSubmitted());
+                            }
+                          : null,
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/login/login_screen.dart
+++ b/lib/features/auth/presentation/pages/login/login_screen.dart
@@ -10,7 +10,7 @@ import 'package:zendvo/features/auth/presentation/bloc/login/login_event.dart';
 import 'package:zendvo/features/auth/presentation/bloc/login/login_state.dart';
 import 'widgets/login_footer.dart';
 import 'widgets/login_form.dart';
-import 'widgets/login_header.dart';
+import 'package:zendvo/features/auth/presentation/widgets/auth_header.dart';
 import 'widgets/login_title_section.dart';
 
 /// Login screen for user authentication.
@@ -65,7 +65,7 @@ class _LoginView extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SizedBox(height: SizeConfig.getHeight(2)),
-                const LoginHeader(),
+                const AuthHeader(),
                 SizedBox(height: SizeConfig.getHeight(4)),
                 const LoginTitleSection(),
                 SizedBox(height: SizeConfig.getHeight(4)),

--- a/lib/features/auth/presentation/widgets/auth_header.dart
+++ b/lib/features/auth/presentation/widgets/auth_header.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:zendvo/core/constants/app_colors.dart';
 
-class LoginHeader extends StatelessWidget {
-  const LoginHeader({super.key});
+/// Reusable branding header for authentication screens.
+class AuthHeader extends StatelessWidget {
+  const AuthHeader({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,12 +21,12 @@ class LoginHeader extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 12),
-        const Text(
+        Text(
           "Zendvo",
           style: TextStyle(
             fontSize: 24,
             fontWeight: FontWeight.bold,
-            color: AppColors.lightTextHeading,
+            color: AppColors.getHeadingTextColor(context),
           ),
         ),
       ],


### PR DESCRIPTION
## Summary

Implemented the Forgot Password flow with Bloc state management, email validation, and navigation support.

## Changes

Created ForgotPasswordBloc, ForgotPasswordEvent, and ForgotPasswordState to manage form validation and submission flow.

Added forgot_password_screen.dart using shared authentication components and matching the provided design.

Refactored LoginHeader into a reusable AuthHeader widget and updated LoginScreen to use the shared component.

Registered the /forgot-password and /verify-email routes in AppRouter.

Added email validation and form state handling with success navigation to the verification screen.

## Verification

Verified navigation from Login to Forgot Password and from Forgot Password to Verify Email.

Verified invalid email inputs prevent submission.

Verified valid email inputs enable submission and trigger successful navigation.

Closes #30 

## Screenshots
<img width="1918" height="840" alt="image" src="https://github.com/user-attachments/assets/25b59f28-2723-4fa0-949b-3e1d52bbe183" />


